### PR TITLE
Bring 3.1.1 patch to remove log statement

### DIFF
--- a/recipe/gh426_logmsg.patch
+++ b/recipe/gh426_logmsg.patch
@@ -1,0 +1,28 @@
+From 6105b1aa50338d1380f7ccad4f6f007c77f6519f Mon Sep 17 00:00:00 2001
+From: Jason Madden <jamadden@gmail.com>
+Date: Fri, 13 Sep 2024 04:55:06 -0500
+Subject: [PATCH] Remove unnecessary logging during interpreter shutdown. Fixes
+ #426.
+
+---
+ src/greenlet/TThreadStateDestroy.cpp | 4 ++++
+ 1 files changed, 4 insertions(+)
+
+diff --git a/src/greenlet/TThreadStateDestroy.cpp b/src/greenlet/TThreadStateDestroy.cpp
+index 3aab2e7..e5a9661 100644
+--- a/src/greenlet/TThreadStateDestroy.cpp
++++ b/src/greenlet/TThreadStateDestroy.cpp
+@@ -108,9 +108,13 @@ struct ThreadState_DestroyNoGIL
+ #else
+         if (_Py_IsFinalizing()) {
+ #endif
++#ifdef GREENLET_DEBUG
++            // No need to log in the general case. Yes, we'll leak,
++            // but we're shutting down so it should be ok.
+             fprintf(stderr,
+                     "greenlet: WARNING: Interpreter is finalizing. Ignoring "
+                     "call to Py_AddPendingCall; \n");
++#endif
+             return 0;
+         }
+         return Py_AddPendingCall(func, arg);

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "greenlet" %}
 {% set version = "3.1.0" %}
+# Consider removing the patch below when 3.1.1 release (#44).
 
 package:
   name: {{ name|lower }}
@@ -9,7 +10,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: b395121e9bbe8d02a750886f108d540abe66075e61e22f7353d9acb0b81be0f0
   patches:
-    # python-greenlet/greenlet#426 remove with 3.1.1 release
+    # python-greenlet/greenlet#426 remove with 3.1.1 release (#44).
     - gh426_logmsg.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,12 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: b395121e9bbe8d02a750886f108d540abe66075e61e22f7353d9acb0b81be0f0
+  patches:
+    # python-greenlet/greenlet#426 remove with 3.1.1 release
+    - gh426_logmsg.patch
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

greenlet 3.1.0 has a stray `printf` statement that is causing me grief :)  Upstream quickly patched it, see: python-greenlet/greenlet#426 , but am unsure how soon a new release is coming, so figured I would bring this patch here. Thank you for the consideration.

@conda-forge-admin please rerender